### PR TITLE
Use `alpine:3.16`

### DIFF
--- a/ghc-9.0.2/Dockerfile
+++ b/ghc-9.0.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.16
 # Install deps for:
 # - ghc/cabal: curl gcc g++ gmp-dev ncurses-dev libffi-dev make xz tar perl zlib-dev
 # - repo clone: git
@@ -7,6 +7,9 @@ FROM alpine:edge
 # - to use embedded binaries in development (ie themis): libc6-compat
 # - for nix installation via github action cachix/install-nix-action: sudo
 RUN apk --no-cache add binutils-gold curl gcc g++ git gmp-dev ncurses-dev ncurses-static libffi-dev make xz tar perl zlib-dev zlib-static bash sudo libc6-compat git-lfs
+
+# Install system deps for FOSSA CLI:
+RUN apk --no-cache add bash xz-libs xz-dev bzip2-dev bzip2-static upx curl jq
 
 # manual installation of ghcup -- the install script doesn't work headless
 RUN mkdir -p ~/.ghcup/bin && curl https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup > ~/.ghcup/bin/ghcup && chmod +x ~/.ghcup/bin/ghcup


### PR DESCRIPTION
`alpine:edge` no longer contains `liblzma.a`. Drop to `alpine:3.16`.

I tried to test with the following script:
```
docker build --platform linux/amd64 -t local-haskell-static-alpine ghc-9.0.2
cd ../fossa-cli
echo 'FROM local-haskell-static-alpine' > Dockerfile
echo 'WORKDIR /app' >> Dockerfile
echo 'RUN cabal update' >> Dockerfile
docker build --platform linux/amd64 -t fossa-cli .
docker run --platform linux/amd64 --workdir=/app --rm -v $(pwd):/app fossa-cli cabal build --enable-executable-static
```

... but QEMU promptly eats 30GB+ of memory and then my system kills the build. Anyone on `x86_64` willing to test?

**Edit**: Oh, CI just pushes regardless. Well, I'll try in CI then.