### PR TITLE
Dockerfile for building a GHC 9.2.6 image.

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -18,6 +18,7 @@ jobs:
           - ghc-8.8.4 
           - ghc-8.10.7
           - ghc-9.0.2
+          - ghc-9.2.5
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -18,7 +18,7 @@ jobs:
           - ghc-8.8.4 
           - ghc-8.10.7
           - ghc-9.0.2
-          - ghc-9.2.5
+          - ghc-9.2.6
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Supported versions are:
 - `ghc-8.10.4`
 - `ghc-8.10.7`
 - `ghc-9.0.2`
+- `ghc-9.2.6`
 
 ### Building your executable
 

--- a/ghc-9.2.6/Dockerfile
+++ b/ghc-9.2.6/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:3.16
+# Install deps for:
+# - ghc/cabal: curl gcc g++ gmp-dev ncurses-dev libffi-dev make xz tar perl zlib-dev
+# - repo clone: git
+# - static builds: zlib-static HACK(broken-ghc-musl): ncurses-static
+# - random haskell libraries with cbits (basement): binutils-gold
+# - to use embedded binaries in development (ie themis): libc6-compat
+# - for nix installation via github action cachix/install-nix-action: sudo
+RUN apk --no-cache add binutils-gold curl gcc g++ git gmp-dev ncurses-dev ncurses-static libffi-dev make xz tar perl zlib-dev zlib-static bash sudo libc6-compat git-lfs
+
+# Install system deps for FOSSA CLI:
+RUN apk --no-cache add bash xz-libs xz-dev bzip2-dev bzip2-static upx curl jq
+
+# manual installation of ghcup -- the install script doesn't work headless
+RUN mkdir -p ~/.ghcup/bin && curl https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup > ~/.ghcup/bin/ghcup && chmod +x ~/.ghcup/bin/ghcup
+ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:$PATH"
+
+RUN ghcup install ghc 9.2.6
+
+RUN ghcup set ghc 9.2.6
+RUN ghcup install cabal
+
+# Sets USER environment to overcome issue, as described in:
+# https://github.com/cachix/install-nix-action/issues/122
+ENV USER=guest


### PR DESCRIPTION
I was able to get the cli building with GHC `9.2.6` over in this [branch](https://github.com/fossas/fossa-cli/tree/ghc-9.2). This PR is meant to be a basis for a future `haskell-dev-tools` image based on 9.2.

Currently only ghc `9.2.5` ~~supports HLS~~ has HLS on ghcup, but I thought we could develop with 9.2.5 locally and build in ci with 9.2.6 until it does, or build HLS ourselves using ghcup locally. The GHC maintainers [encouraged](https://www.haskell.org/ghc/blog/20230210-ghc-9.2.6-released.html) upgrading to `9.2.6` quickly due to some correctness issues in 9.2.5. 