### PR TITLE
Ghc 9.4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Supported versions are:
 - `ghc-8.10.4`
 - `ghc-8.10.7`
 - `ghc-9.0.2`
+- `ghc-9.4.4`
 
 ### Building your executable
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Supported versions are:
 - `ghc-8.10.4`
 - `ghc-8.10.7`
 - `ghc-9.0.2`
-- `ghc-9.4.4`
+- `ghc-9.4.7`
 
 ### Building your executable
 

--- a/ghc-9.4.4/Dockerfile
+++ b/ghc-9.4.4/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:3.16
+# Install deps for:
+# - ghc/cabal: curl gcc g++ gmp-dev ncurses-dev libffi-dev make xz tar perl zlib-dev
+# - repo clone: git
+# - static builds: zlib-static HACK(broken-ghc-musl): ncurses-static
+# - random haskell libraries with cbits (basement): binutils-gold
+# - to use embedded binaries in development (ie themis): libc6-compat
+# - for nix installation via github action cachix/install-nix-action: sudo
+RUN apk --no-cache add binutils-gold curl gcc g++ git gmp-dev ncurses-dev ncurses-static libffi-dev make xz tar perl zlib-dev zlib-static bash sudo libc6-compat git-lfs
+
+# Install system deps for FOSSA CLI:
+RUN apk --no-cache add bash xz-libs xz-dev bzip2-dev bzip2-static upx curl jq
+
+# manual installation of ghcup -- the install script doesn't work headless
+RUN mkdir -p ~/.ghcup/bin && curl https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup > ~/.ghcup/bin/ghcup && chmod +x ~/.ghcup/bin/ghcup
+ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:$PATH"
+
+RUN ghcup install ghc 9.4.4
+
+RUN ghcup set ghc 9.4.4
+RUN ghcup install cabal
+
+# Sets USER environment to overcome issue, as described in:
+# https://github.com/cachix/install-nix-action/issues/122
+ENV USER=guest

--- a/ghc-9.4.7/Dockerfile
+++ b/ghc-9.4.7/Dockerfile
@@ -1,3 +1,9 @@
+# There are more recent versions of Alpine.
+# However, they have a version of pkg-config which changed its output in a way cabal doesn't understand.
+# See: https://github.com/haskell/cabal/issues/8923
+# There is a workaround script, but I don't think it's worth it since alpine:3.16 is still maintained as of 9/2023.
+# If you try to upgrade and have trouble building, it may be related to the above.
+
 FROM alpine:3.16
 # Install deps for:
 # - ghc/cabal: curl gcc g++ gmp-dev ncurses-dev libffi-dev make xz tar perl zlib-dev
@@ -15,10 +21,10 @@ RUN apk --no-cache add bash xz-libs xz-dev bzip2-dev bzip2-static upx curl jq
 RUN mkdir -p ~/.ghcup/bin && curl https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup > ~/.ghcup/bin/ghcup && chmod +x ~/.ghcup/bin/ghcup
 ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:$PATH"
 
-RUN ghcup install ghc 9.4.4
+RUN ghcup install ghc 9.4.7
 
-RUN ghcup set ghc 9.4.4
-RUN ghcup install cabal
+RUN ghcup set ghc 9.4.7
+RUN ghcup install cabal 3.10.1.0
 
 # Sets USER environment to overcome issue, as described in:
 # https://github.com/cachix/install-nix-action/issues/122


### PR DESCRIPTION
With the release of GHC 9.4.7 there are new bindists of GHC for alpine which avoid the bug in [23043](https://gitlab.haskell.org/ghc/ghc/-/issues/23043).

I built this Docker file, then ran it with `docker run -it <image>` and manually went through the process of building the CLI, including embedding our other binaries. I then copied the resulting `fossa` binary into a new ubuntu container I ran interactively. 

Running `ldd fossa` gives:
<img width="307" alt="Screenshot 2023-09-06 at 5 07 28 PM" src="https://github.com/fossas/haskell-static-alpine/assets/190980/4c8c5765-deb1-41c0-a28d-d757ec52e86d">

Then as another test I ran a license scan, ensuring that `themis` would be run:
```sh
$ mkdir tmp
$ touch tmp/foo.txt
$ ./fossa license-scan direct tmp/
[
  {
    "Name": "No_license_found",
    "Type": "LicenseUnit",
    "Dir": "",
    "Files": [
      "foo.txt"
    ],
    "Data": [
      {
        "path": "foo.txt",
        "ThemisVersion": "729499e2db6d4a69f17d8565a34b148e750a7d06"
      }
    ],
    "Repo": "",
    "Ops": {},
    "Config": {},
    "Info": {
      "Description": ""
    },
    "Dependencies": []
  }
]
```