### PR TITLE
Add a release for GHC 9.8.2

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,6 +20,7 @@ jobs:
           - ghc-9.0.2
           - ghc-9.4.7
           - ghc-9.4.8
+          - ghc-9.8.2
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Supported versions are:
 - `ghc-8.10.7`
 - `ghc-9.0.2`
 - `ghc-9.4.7`
+- `ghc-9.4.8`
+- `ghc-9.8.2`
 
 ### Building your executable
 

--- a/ghc-9.8.2/Dockerfile
+++ b/ghc-9.8.2/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:3.17
+# Install deps for:
+# - ghc/cabal: curl gcc g++ gmp-dev ncurses-dev libffi-dev make xz tar perl zlib-dev
+# - repo clone: git
+# - static builds: zlib-static HACK(broken-ghc-musl): ncurses-static
+# - random haskell libraries with cbits (basement): binutils-gold
+# - to use embedded binaries in development (ie themis): libc6-compat
+# - for nix installation via github action cachix/install-nix-action: sudo
+RUN apk --no-cache add binutils-gold curl gcc g++ git gmp-dev ncurses-dev ncurses-static libffi-dev make xz tar perl zlib-dev zlib-static bash sudo libc6-compat git-lfs
+
+# Install system deps for FOSSA CLI:
+RUN apk --no-cache add bash xz-libs xz-dev bzip2-dev bzip2-static upx curl jq
+
+# manual installation of ghcup -- the install script doesn't work headless
+RUN mkdir -p ~/.ghcup/bin && curl https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup > ~/.ghcup/bin/ghcup && chmod +x ~/.ghcup/bin/ghcup
+ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:$PATH"
+
+RUN ghcup install ghc 9.8.2
+
+RUN ghcup set ghc 9.8.2
+RUN ghcup install cabal 3.10.3.0
+
+# Sets USER environment to overcome issue, as described in:
+# https://github.com/cachix/install-nix-action/issues/122
+ENV USER=guest

--- a/ghc-9.8.2/Dockerfile
+++ b/ghc-9.8.2/Dockerfile
@@ -11,9 +11,10 @@ RUN apk --no-cache add binutils-gold curl gcc g++ git gmp-dev ncurses-dev ncurse
 # Install system deps for FOSSA CLI:
 RUN apk --no-cache add bash xz-libs xz-dev bzip2-dev bzip2-static upx curl jq
 
-# manual installation of ghcup -- the install script doesn't work headless
-RUN mkdir -p ~/.ghcup/bin && curl https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup > ~/.ghcup/bin/ghcup && chmod +x ~/.ghcup/bin/ghcup
+ENV BOOTSTRAP_HASKELL_NONINTERACTIVE=1
+ENV BOOTSTRAP_HASKELL_MINIMAL=1
 ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:$PATH"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
 RUN ghcup install ghc 9.8.2
 


### PR DESCRIPTION
I want to test building the CLI using GHC 9.8.2. The main reason for this is that 9.8.2 is the first release where I should be able to get [arm binaries for GHC ](https://www.haskell.org/ghc/download_ghc_9_8_2.html#linux_aarch64) and cabal that have been compiled against musl libc. Eventually, this will allow building a version of this image for arm on linux.

9.4 is also not receiving any ongoing development.

