### PR TITLE
Add xz-static for alpine 3.17 based builds.

### DIFF
--- a/ghc-9.8.2/Dockerfile
+++ b/ghc-9.8.2/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3.17
 # - random haskell libraries with cbits (basement): binutils-gold
 # - to use embedded binaries in development (ie themis): libc6-compat
 # - for nix installation via github action cachix/install-nix-action: sudo
-RUN apk --no-cache add binutils-gold curl gcc g++ git gmp-dev ncurses-dev ncurses-static libffi-dev make xz tar perl zlib-dev zlib-static bash sudo libc6-compat git-lfs
+RUN apk --no-cache add binutils-gold curl gcc g++ git gmp-dev ncurses-dev ncurses-static libffi-dev make xz xz-static tar perl zlib-dev zlib-static bash sudo libc6-compat git-lfs
 
 # Install system deps for FOSSA CLI:
 RUN apk --no-cache add bash xz-libs xz-dev bzip2-dev bzip2-static upx curl jq
@@ -16,7 +16,8 @@ ENV BOOTSTRAP_HASKELL_MINIMAL=1
 ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:$PATH"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
-RUN ghcup install ghc 9.8.2
+# Delete the documentation, we don't really need it.
+RUN ghcup install ghc 9.8.2 && rm -rf "$HOME/.ghcup/share/doc/*"
 
 RUN ghcup set ghc 9.8.2
 RUN ghcup install cabal 3.10.3.0


### PR DESCRIPTION
I missed a dep for building the CLI in my earlier 9.8.2 based builds, this adds it. It also adds a line to delete docs installed with GHC, since they take up ~500 MB and aren't needed IMO. 