### PR TITLE
Multiplatform GHC 9.8 image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          file: ${{ format('./{0}', matrix.ghc-version) }}
+          file: ${{ format('./{0}/Dockerfile', matrix.ghc-version) }}
           push: false # ${{ github.ref == 'refs/heads/master' }}
           tags: ${{ format('{0}:{1}', env.IMAGE_NAME, matrix.ghc-version) }}
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -37,9 +37,6 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      # - name: Build image
-      #   run: docker build ./${{ matrix.ghc-version }} --platform ${{ matrix.platform }} --tag $IMAGE_NAME:${{ matrix.ghc-version }}
-
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/login-action@v3
@@ -52,13 +49,5 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           file: ${{ format('./{0}/Dockerfile', matrix.ghc-version) }}
-          push: false # ${{ github.ref == 'refs/heads/master' }}
+          push: ${{ github.ref == 'refs/heads/master' }}
           tags: ${{ format('{0}:{1}', env.IMAGE_NAME, matrix.ghc-version) }}
-
-      # - name: Log into registry
-      #   if: ${{ github.ref == 'refs/heads/master' }}
-      #   run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u fossabot --password-stdin
-
-      # - name: Push image
-      #   if: ${{ github.ref == 'refs/heads/master' }}
-      #   run: docker push $IMAGE_NAME:${{ matrix.ghc-version }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -53,7 +53,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ${{ format('./{0}', matrix.ghc-version) }}
           push: false # ${{ github.ref == 'refs/heads/master' }}
-          tags: ${{ format('{0}:{1}', env.IMAGE_NAME, matrix.ghc-version }}
+          tags: ${{ format('{0}:{1}', env.IMAGE_NAME, matrix.ghc-version) }}
 
       # - name: Log into registry
       #   if: ${{ github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -14,21 +14,28 @@ jobs:
 
     strategy:
       matrix:
-        ghc-version: 
-          - ghc-8.8.4 
-          - ghc-8.10.7
-          - ghc-9.0.2
-          - ghc-9.4.7
-          - ghc-9.4.8
-          - ghc-9.8.2
+        include:
+          - ghc-version: ghc-8.8.4
+            platform: linux/amd64
+          - ghc-version: ghc-8.10.7
+            platform: linux/amd64
+          - ghc-version: ghc-9.0.2
+            platform: linux/amd64
+          - ghc-version: ghc-9.4.7
+            platform: linux/amd64
+          - ghc-version: ghc-9.4.8
+            platform: linux/amd64
+          - ghc-version: ghc-9.8.2
+            platform: linux/amd64,linux/arm64
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build ./${{ matrix.ghc-version }} --tag $IMAGE_NAME:${{ matrix.ghc-version }}
+        run: docker build ./${{ matrix.ghc-version }} --platform ${{ matrix.platform }} --tag $IMAGE_NAME:${{ matrix.ghc-version }}
 
       - name: Log into registry
+        if: ${{ github.ref == 'refs/heads/master' }}
         run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u fossabot --password-stdin
 
       - name: Push image

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           file: ${{ format('./{0}/Dockerfile', matrix.ghc-version) }}
           push: false # ${{ github.ref == 'refs/heads/master' }}
           tags: ${{ format('{0}:{1}', env.IMAGE_NAME, matrix.ghc-version) }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/login-action@v3
         with:
-          username: ${{ fossabot }}
+          username: fossabot
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -29,6 +29,12 @@ jobs:
             platform: linux/amd64,linux/arm64
 
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - uses: actions/checkout@v2
 
       - name: Build image

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -37,13 +37,28 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Build image
-        run: docker build ./${{ matrix.ghc-version }} --platform ${{ matrix.platform }} --tag $IMAGE_NAME:${{ matrix.ghc-version }}
+      # - name: Build image
+      #   run: docker build ./${{ matrix.ghc-version }} --platform ${{ matrix.platform }} --tag $IMAGE_NAME:${{ matrix.ghc-version }}
 
-      - name: Log into registry
+      - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u fossabot --password-stdin
+        uses: docker/login-action@v3
+        with:
+          username: ${{ fossabot }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Push image
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: docker push $IMAGE_NAME:${{ matrix.ghc-version }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          file: ${{ format('./{0}', matrix.ghc-version) }}
+          push: false # ${{ github.ref == 'refs/heads/master' }}
+          tags: ${{ format('{0}:{1}', env.IMAGE_NAME, matrix.ghc-version }}
+
+      # - name: Log into registry
+      #   if: ${{ github.ref == 'refs/heads/master' }}
+      #   run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u fossabot --password-stdin
+
+      # - name: Push image
+      #   if: ${{ github.ref == 'refs/heads/master' }}
+      #   run: docker push $IMAGE_NAME:${{ matrix.ghc-version }}

--- a/ghc-9.8.2/Dockerfile
+++ b/ghc-9.8.2/Dockerfile
@@ -11,15 +11,37 @@ RUN apk --no-cache add binutils-gold curl gcc g++ git gmp-dev ncurses-dev ncurse
 # Install system deps for FOSSA CLI:
 RUN apk --no-cache add bash xz-libs xz-dev bzip2-dev bzip2-static upx curl jq
 
-ENV BOOTSTRAP_HASKELL_NONINTERACTIVE=1
-ENV BOOTSTRAP_HASKELL_MINIMAL=1
+ENV GHC_VERSION="9.8.2"
+
 ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:$PATH"
-RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
-RUN ghcup install ghc 9.8.2
+RUN <<EOF
+  if [ $(uname -m) != "aarch64" ] ; then
+    export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
+    export BOOTSTRAP_HASKELL_MINIMAL=1
+    curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
-RUN ghcup set ghc 9.8.2
-RUN ghcup install cabal 3.10.3.0
+    ghcup install ghc "$GHC_VERSION"
+    ghcup set ghc "$GHC_VERSION"
+  else
+    mkdir /tmp/ghc
+    curl "https://downloads.haskell.org/~ghc/$GHC_VERSION/ghc-$GHC_VERSION-aarch64-alpine3_18-linux.tar.xz" | tar --strip-components=1 -xJC /tmp/ghc
+    cd /tmp/ghc
+    ./configure --prefix="$HOME/.ghcup" && make install && rm -rf /tmp/ghc
+  fi
+EOF
+
+# Install cabal
+RUN <<EOF
+  if [ $(uname -m) != "aarch64" ] ; then
+    ghcup install cabal 3.10.3.0
+  else
+    curl https://downloads.haskell.org/~cabal/cabal-install-3.12.1.0/cabal-install-3.12.1.0-aarch64-linux-alpine3_18.tar.xz | tar -xJC "$HOME/.ghcup/bin/"
+    chmod 755 "$HOME/.ghcup/bin/cabal"
+    rm "$HOME/.ghcup/bin/plan.json"
+  fi
+EOF
+
 
 # Sets USER environment to overcome issue, as described in:
 # https://github.com/cachix/install-nix-action/issues/122

--- a/ghc-9.8.2/Dockerfile
+++ b/ghc-9.8.2/Dockerfile
@@ -29,6 +29,10 @@ RUN <<EOF
     cd /tmp/ghc
     ./configure --prefix="$HOME/.ghcup" && make install && rm -rf /tmp/ghc
   fi
+
+  # Docs take up a lot of space in the image and aren't really necessary.
+  rm -rf "$HOME/.ghcup/share/doc"
+
 EOF
 
 # Install cabal
@@ -41,7 +45,6 @@ RUN <<EOF
     rm "$HOME/.ghcup/bin/plan.json"
   fi
 EOF
-
 
 # Sets USER environment to overcome issue, as described in:
 # https://github.com/cachix/install-nix-action/issues/122

--- a/ghc-9.8.2/Dockerfile
+++ b/ghc-9.8.2/Dockerfile
@@ -15,6 +15,11 @@ ENV GHC_VERSION="9.8.2"
 
 ENV PATH="/root/.cabal/bin:/root/.ghcup/bin:$PATH"
 
+# There aren't official builds of ghcup that are built against musl for aarch64.
+# So the following two steps do the install manually on that platform.
+# They manually do the same steps that ghcup would.
+# ghcup should have support for this soon: https://github.com/haskell/ghcup-hs/issues/1012#issuecomment-2294829976
+# When that happens, you should be able to remove the 'else' branches and have the install work for all platforms.
 RUN <<EOF
   if [ $(uname -m) != "aarch64" ] ; then
     export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
@@ -40,7 +45,7 @@ RUN <<EOF
   if [ $(uname -m) != "aarch64" ] ; then
     ghcup install cabal 3.10.3.0
   else
-    curl https://downloads.haskell.org/~cabal/cabal-install-3.12.1.0/cabal-install-3.12.1.0-aarch64-linux-alpine3_18.tar.xz | tar -xJC "$HOME/.ghcup/bin/"
+    curl https://downloads.haskell.org/~ghcup/unofficial-bindists/cabal/3.10.3.0/cabal-install-3.10.3.0-aarch64-alpine3_20.tar.xz | tar -xJC "$HOME/.ghcup/bin/"
     chmod 755 "$HOME/.ghcup/bin/cabal"
     rm "$HOME/.ghcup/bin/plan.json"
   fi


### PR DESCRIPTION
Edit the dockerfile for 9.8.2 to build both an arm image and an amd64 image. You can see the build logs [here](https://github.com/fossas/haskell-static-alpine/actions/runs/10475508289/job/29012321523).